### PR TITLE
Drop-in replace VoiceSession for ChatManager.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "classnames": "^2.3.2",
     "eslint": "8.42.0",
     "eslint-config-next": "^14.0.1",
+    "fixie-web": "1.0.7",
     "livekit-client": "^1.14.4",
     "lodash": "^4.17.21",
     "next": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "classnames": "^2.3.2",
     "eslint": "8.42.0",
     "eslint-config-next": "^14.0.1",
-    "fixie-web": "1.0.7",
+    "fixie-web": "1.0.8",
     "livekit-client": "^1.14.4",
     "lodash": "^4.17.21",
     "next": "^14.0.1",

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -2,7 +2,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSwipeable } from "react-swipeable";
-import { ChatManager, ChatManagerState, createChatManager } from "./chat";
+import { FixieClient, VoiceSession, VoiceSessionInit, VoiceSessionState } from "fixie-web";
 import { getAgent, getAgentImageUrl } from "./agents";
 import Image from "next/image";
 import "../globals.css";
@@ -140,7 +140,7 @@ const Stat: React.FC<{ name: string; latency: number; showName?: boolean }> = ({
 const Visualizer: React.FC<{
   width?: number;
   height?: number;
-  state?: ChatManagerState;
+  state?: VoiceSessionState;
   inputAnalyzer?: AnalyserNode;
   outputAnalyzer?: AnalyserNode;
 }> = ({ width, height, state, inputAnalyzer, outputAnalyzer }) => {
@@ -164,7 +164,7 @@ const Visualizer: React.FC<{
   }
   const draw = (
     canvas: HTMLCanvasElement,
-    state: ChatManagerState,
+    state: VoiceSessionState,
     freqData: Uint8Array,
   ) => {
     const ctx = canvas.getContext("2d") as CanvasRenderingContext2D;
@@ -177,11 +177,11 @@ const Visualizer: React.FC<{
       const x = barHeight + 25 * (i / freqData.length);
       const y = 250 * (i / freqData.length);
       const z = 50;
-      if (state == ChatManagerState.LISTENING) {
+      if (state == VoiceSessionState.LISTENING) {
         ctx.fillStyle = `rgb(${x},${y},${z})`;
-      } else if (state == ChatManagerState.THINKING) {
+      } else if (state == VoiceSessionState.THINKING) {
         ctx.fillStyle = `rgb(${z},${x},${y})`;
-      } else if (state == ChatManagerState.SPEAKING) {
+      } else if (state == VoiceSessionState.SPEAKING) {
         ctx.fillStyle = `rgb(${y},${z},${x})`;
       }
       ctx.fillRect(
@@ -195,13 +195,13 @@ const Visualizer: React.FC<{
   const render = useCallback(() => {
     let freqData: Uint8Array = new Uint8Array(0);
     switch (state) {
-      case ChatManagerState.LISTENING:
+      case VoiceSessionState.LISTENING:
         if (!inputAnalyzer) return;
         freqData = new Uint8Array(inputAnalyzer!.frequencyBinCount);
         inputAnalyzer!.getByteFrequencyData(freqData);
         freqData = freqData.slice(0, 16);
         break;
-      case ChatManagerState.THINKING:
+      case VoiceSessionState.THINKING:
         freqData = new Uint8Array(16);
         // make the data have random pulses based on performance.now, which decay over time
         const now = performance.now();
@@ -210,14 +210,14 @@ const Visualizer: React.FC<{
             Math.max(0, Math.sin((now - i * 100) / 100) * 128 + 128) / 2;
         }
         break;
-      case ChatManagerState.SPEAKING:
+      case VoiceSessionState.SPEAKING:
         if (!outputAnalyzer) return;
         freqData = new Uint8Array(outputAnalyzer!.frequencyBinCount);
         outputAnalyzer!.getByteFrequencyData(freqData);
         freqData = freqData.slice(0, 16);
         break;
     }
-    draw(canvasRef.current!, state ?? ChatManagerState.IDLE, freqData);
+    draw(canvasRef.current!, state ?? VoiceSessionState.IDLE, freqData);
     requestAnimationFrame(render);
   }, [state, inputAnalyzer, outputAnalyzer]);
   useEffect(() => render(), [state]);
@@ -250,6 +250,46 @@ const Button: React.FC<{
   </button>
 );
 
+/** Create a VoiceSession with the given parameters. */
+function makeVoiceSession({
+  agentId,
+  asrProvider,
+  asrLanguage,
+  ttsProvider,
+  ttsModel,
+  ttsVoice,
+  model,
+  webrtcUrl,
+}: {
+  agentId: string;
+  asrProvider?: string;
+  asrLanguage?: string;
+  ttsProvider?: string;
+  ttsModel?: string;
+  ttsVoice?: string;
+  model?: string;
+  webrtcUrl?: string;
+}): VoiceSession {
+  console.log(`[makeVoiceSession] creating voice session with LLM ${model}`);
+  const fixieClient = new FixieClient({});
+  const voiceInit: VoiceSessionInit = {
+    webrtcUrl: webrtcUrl || 'wss://wsapi.fixie.ai',
+    asrProvider: asrProvider || DEFAULT_ASR_PROVIDER,
+    asrLanguage: asrLanguage || 'en-US',
+    ttsProvider: ttsProvider || DEFAULT_TTS_PROVIDER,
+    ttsModel: ttsModel || '',
+    ttsVoice: ttsVoice || '',
+    model: model || DEFAULT_LLM,
+  };
+  const session = fixieClient.createVoiceSession({
+    agentId,
+    init: voiceInit,
+  });
+  console.log(`[makeVoiceSession] created voice session`);
+  return session;
+}
+
+
 const AgentPageComponent: React.FC = () => {
   const searchParams = useSearchParams();
   const agentId = searchParams.get("agent") || "dr-donut";
@@ -277,7 +317,7 @@ const AgentPageComponent: React.FC = () => {
   const [showStats, setShowStats] = useState(
     searchParams.get("stats") !== null,
   );
-  const [chatManager, setChatManager] = useState<ChatManager | null>();
+  const [voiceSession, setVoiceSession] = useState<VoiceSession | null>();
   const [input, setInput] = useState("");
   const [output, setOutput] = useState("");
   const [helpText, setHelpText] = useState(idleText);
@@ -286,7 +326,7 @@ const AgentPageComponent: React.FC = () => {
   const [llmTokenLatency, setLlmTokenLatency] = useState(0);
   const [ttsLatency, setTtsLatency] = useState(0);
   const active = () =>
-    chatManager && chatManager!.state != ChatManagerState.IDLE;
+    voiceSession && voiceSession!.state != VoiceSessionState.DISCONNECTED;
   useEffect(
     () => init(),
     [
@@ -304,44 +344,42 @@ const AgentPageComponent: React.FC = () => {
     console.log(
       `[page] init asr=${asrProvider} tts=${ttsProvider} llm=${model} agent=${agentId} docs=${docs}`,
     );
-    const manager = createChatManager({
+    const session = makeVoiceSession({
       asrProvider,
-      asrModel,
       asrLanguage,
       ttsProvider,
       ttsModel,
       ttsVoice,
       model,
       agentId,
-      docs,
       webrtcUrl,
     });
-    setChatManager(manager);
-    manager.onStateChange = (state) => {
+    setVoiceSession(session);
+    session.onStateChange = (state: VoiceSessionState) => {
       switch (state) {
-        case ChatManagerState.LISTENING:
+        case VoiceSessionState.LISTENING:
           setHelpText("Listening...");
           break;
-        case ChatManagerState.THINKING:
+        case VoiceSessionState.THINKING:
           setHelpText(`Thinking... ${tapOrClick.toLowerCase()} to cancel`);
           break;
-        case ChatManagerState.SPEAKING:
+        case VoiceSessionState.SPEAKING:
           setHelpText(`Speaking... ${tapOrClick.toLowerCase()} to interrupt`);
           break;
         default:
           setHelpText(idleText);
       }
     };
-    manager.onInputChange = (text, final) => {
+    session.onInputChange = (text, final) => {
       setInput(text);
     };
-    manager.onOutputChange = (text, final) => {
+    session.onOutputChange = (text, final) => {
       setOutput(text);
       if (final) {
         setInput("");
       }
     };
-    manager.onLatencyChange = (kind, latency) => {
+    session.onLatencyChange = (kind, latency) => {
       switch (kind) {
         case "asr":
           setAsrLatency(latency);
@@ -360,10 +398,10 @@ const AgentPageComponent: React.FC = () => {
           break;
       }
     };
-    manager.onError = () => {
-      manager.stop();
+    session.onError = () => {
+      session.stop();
     };
-    return () => manager.stop();
+    return () => session.stop();
   };
   const changeAgent = (delta: number) => {
     const index = AGENT_IDS.indexOf(agentId);
@@ -377,12 +415,12 @@ const AgentPageComponent: React.FC = () => {
     setLlmResponseLatency(0);
     setLlmTokenLatency(0);
     setTtsLatency(0);
-    chatManager!.start("");
+    voiceSession!.start();
   };
   const handleStop = () => {
-    chatManager!.stop();
+    voiceSession!.stop();
   };
-  const speak = () => (active() ? chatManager!.interrupt() : handleStart());
+  const speak = () => (active() ? voiceSession!.interrupt() : handleStart());
   // Click/tap starts or interrupts.
   const onClick = (event: MouseEvent) => {
     const target = event.target as HTMLElement;
@@ -524,9 +562,9 @@ const AgentPageComponent: React.FC = () => {
         <div className="w-full max-w-sm p-4">
           <Visualizer
             height={64}
-            state={chatManager?.state}
-            inputAnalyzer={chatManager?.inputAnalyzer}
-            outputAnalyzer={chatManager?.outputAnalyzer}
+            state={voiceSession?.state}
+            inputAnalyzer={voiceSession?.inputAnalyzer}
+            outputAnalyzer={voiceSession?.outputAnalyzer}
           />
         </div>
         <div className="w-full flex justify-center mt-3">

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -2,7 +2,12 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSwipeable } from "react-swipeable";
-import { FixieClient, VoiceSession, VoiceSessionInit, VoiceSessionState } from "fixie-web";
+import {
+  FixieClient,
+  VoiceSession,
+  VoiceSessionInit,
+  VoiceSessionState,
+} from "fixie-web";
 import { getAgent, getAgentImageUrl } from "./agents";
 import Image from "next/image";
 import "../globals.css";
@@ -287,7 +292,8 @@ const AgentPageComponent: React.FC = () => {
   const [ttsLatency, setTtsLatency] = useState(0);
   const active = () =>
     voiceSession && voiceSession!.state != VoiceSessionState.DISCONNECTED;
-  useEffect(() => init(),
+  useEffect(
+    () => init(),
     [
       asrProvider,
       asrLanguage,
@@ -311,7 +317,7 @@ const AgentPageComponent: React.FC = () => {
       ttsProvider,
       ttsModel,
       ttsVoice,
-      model
+      model,
     };
     const session = fixieClient.createVoiceSession({
       agentId,

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -287,8 +287,7 @@ const AgentPageComponent: React.FC = () => {
   const [ttsLatency, setTtsLatency] = useState(0);
   const active = () =>
     voiceSession && voiceSession!.state != VoiceSessionState.DISCONNECTED;
-  useEffect(
-    () => init(),
+  useEffect(() => init(),
     [
       asrProvider,
       asrLanguage,
@@ -366,7 +365,12 @@ const AgentPageComponent: React.FC = () => {
       session.stop();
     };
     session.warmup();
-    return () => session.stop();
+    return () => {
+      session.stop().then(
+        () => console.log("[page] session stopped"),
+        (e) => console.error("[page] session stop error", e),
+      );
+    };
   };
   const changeAgent = (delta: number) => {
     const index = AGENT_IDS.indexOf(agentId);

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -415,6 +415,7 @@ const AgentPageComponent: React.FC = () => {
     setLlmResponseLatency(0);
     setLlmTokenLatency(0);
     setTtsLatency(0);
+    voiceSession!.warmup();
     voiceSession!.start();
   };
   const handleStop = () => {

--- a/src/app/agent/page.tsx
+++ b/src/app/agent/page.tsx
@@ -286,7 +286,7 @@ const AgentPageComponent: React.FC = () => {
   const [llmTokenLatency, setLlmTokenLatency] = useState(0);
   const [ttsLatency, setTtsLatency] = useState(0);
   const active = () =>
-    voiceSession && voiceSession!.state != VoiceSessionState.DISCONNECTED;
+    voiceSession && voiceSession!.state > VoiceSessionState.IDLE;
   useEffect(
     () => init(),
     [

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fixieai/fixie-common@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@fixieai/fixie-common@npm:1.0.6"
+  dependencies:
+    base64-arraybuffer: "npm:^1.0.2"
+    type-fest: "npm:^4.3.1"
+  checksum: e1ceeed3c249007908fce6f5fe0f6cfad62f11fa9f2c6788fa45cbc9301ba802940869c2095b89c7c486a2ec0ae362bdb7561d21ccb73c00ac16cbad0691589e
+  languageName: node
+  linkType: hard
+
 "@graphql-typed-document-node/core@npm:^3.1.1":
   version: 3.2.0
   resolution: "@graphql-typed-document-node/core@npm:3.2.0"
@@ -1929,6 +1939,13 @@ __metadata:
   version: 0.1.0
   resolution: "base-64@npm:0.1.0"
   checksum: 5a42938f82372ab5392cbacc85a5a78115cbbd9dbef9f7540fa47d78763a3a8bd7d598475f0d92341f66285afd377509851a9bb5c67bbecb89686e9255d5b3eb
+  languageName: node
+  linkType: hard
+
+"base64-arraybuffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "base64-arraybuffer@npm:1.0.2"
+  checksum: 15e6400d2d028bf18be4ed97702b11418f8f8779fb8c743251c863b726638d52f69571d4cc1843224da7838abef0949c670bde46936663c45ad078e89fee5c62
   languageName: node
   linkType: hard
 
@@ -3462,6 +3479,7 @@ __metadata:
     eslint: "npm:8.42.0"
     eslint-config-next: "npm:^14.0.1"
     eslint-config-nth: "npm:^2.0.1"
+    fixie-web: "npm:1.0.7"
     livekit-client: "npm:^1.14.4"
     lodash: "npm:^4.17.21"
     next: "npm:^14.0.1"
@@ -3478,6 +3496,28 @@ __metadata:
     word-error-rate: "npm:^0.0.7"
   languageName: unknown
   linkType: soft
+
+"fixie-web@npm:1.0.7":
+  version: 1.0.7
+  resolution: "fixie-web@npm:1.0.7"
+  dependencies:
+    "@fixieai/fixie-common": "npm:^1.0.6"
+    base64-arraybuffer: "npm:^1.0.2"
+    livekit-client: "npm:^1.15.2"
+    type-fest: "npm:^4.3.1"
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react-dom":
+      optional: true
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 8eca64681af049857f02e4447ae89eb559187bc1177981fa9495ae4fc5f571c14bd62925db5eb2c7a6d33889bae5a23ea14d140c0cddf0721d934c635c1cd79b
+  languageName: node
+  linkType: hard
 
 "flat-cache@npm:^3.0.4":
   version: 3.2.0
@@ -5164,7 +5204,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"livekit-client@npm:^1.14.4":
+"livekit-client@npm:^1.14.4, livekit-client@npm:^1.15.2":
   version: 1.15.8
   resolution: "livekit-client@npm:1.15.8"
   dependencies:
@@ -8344,6 +8384,13 @@ __metadata:
   version: 3.13.1
   resolution: "type-fest@npm:3.13.1"
   checksum: 9a8a2359ada34c9b3affcaf3a8f73ee14c52779e89950db337ce66fb74c3399776c697c99f2532e9b16e10e61cfdba3b1c19daffb93b338b742f0acd0117ce12
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.3.1":
+  version: 4.9.0
+  resolution: "type-fest@npm:4.9.0"
+  checksum: 49acfb67999566a24d5604435c8cff786dfc26ebea5a2a343e14d437d34f30a55248f8e597b8f64446c344bb68ce14af68899f562cf66ca66c1e1a856b393259
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3479,7 +3479,7 @@ __metadata:
     eslint: "npm:8.42.0"
     eslint-config-next: "npm:^14.0.1"
     eslint-config-nth: "npm:^2.0.1"
-    fixie-web: "npm:1.0.7"
+    fixie-web: "npm:1.0.8"
     livekit-client: "npm:^1.14.4"
     lodash: "npm:^4.17.21"
     next: "npm:^14.0.1"
@@ -3497,9 +3497,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"fixie-web@npm:1.0.7":
-  version: 1.0.7
-  resolution: "fixie-web@npm:1.0.7"
+"fixie-web@npm:1.0.8":
+  version: 1.0.8
+  resolution: "fixie-web@npm:1.0.8"
   dependencies:
     "@fixieai/fixie-common": "npm:^1.0.6"
     base64-arraybuffer: "npm:^1.0.2"
@@ -3515,7 +3515,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 8eca64681af049857f02e4447ae89eb559187bc1177981fa9495ae4fc5f571c14bd62925db5eb2c7a6d33889bae5a23ea14d140c0cddf0721d934c635c1cd79b
+  checksum: 1b1f7ca0d51c37ef3a4cc677a303a519a64954631f4c82b8d843f88684004822bf263677ca32f804cd2048569fa5c89971aa5c936d122b319835c55569562693
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is the "dumbest" (I think) port to the new VoiceSession interface. I realized that we have a bug in the existing Fixie Voice SDK whereby we don't call warmup() in the VoiceSession ctor, so adding that call is necessary to get this to work as-is. I think it works...

I want to point out the caveats, though. The main one is that there are several known lint issues impacting the use of the useEffect hooks, which means that if certain parameters are changed then the hooks might not run. 

I wasn't sure what to do about the 'docs' and 'asrModel' fields, which would need to be added.


